### PR TITLE
[tool] Fix Travis-CI brew install chrome fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
-
 matrix:
   include:
     - os: osx
       node_js: '8'
       sudo: 'required'
 before_install:
-  - brew update > /dev/null
-  - brew cask install google-chrome
+  - wget https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
+  - hdiutil attach googlechrome.dmg
+  - cp -R "/Volumes/Google Chrome/Google Chrome.app" /Applications
 install:
   - npm install
   - npm run build


### PR DESCRIPTION
1. Changed MacOS install chrome method.
2. Save four minutes